### PR TITLE
[feature] add Heading component with variants and stories

### DIFF
--- a/src/components/ui/heading/README.md
+++ b/src/components/ui/heading/README.md
@@ -1,0 +1,97 @@
+# Heading
+
+A flexible heading component with size variants and polymorphic rendering for heading levels (h1-h6).
+
+## Installation
+
+```bash
+pnpm add @tc96/ui-react
+```
+
+## Usage
+
+```tsx
+import { Heading } from '@tc96/ui-react'
+
+export function Example() {
+  return <Heading>This is a heading</Heading>
+}
+```
+
+## Props
+
+### `as`
+
+Controls which HTML heading element is rendered. Defaults to `h1`.
+
+- **`h1`** - Top-level heading (default)
+- **`h2`** - Second-level heading
+- **`h3`** - Third-level heading
+- **`h4`** - Fourth-level heading
+- **`h5`** - Fifth-level heading
+- **`h6`** - Sixth-level heading
+
+### Examples
+
+```tsx
+<Heading as="h1">Page Title</Heading>
+<Heading as="h2">Section Title</Heading>
+<Heading as="h3">Subsection Title</Heading>
+```
+
+## Sizes
+
+The `size` prop controls the text size independently of the semantic heading level:
+
+- **`2xl`** - Extra extra large (text-5xl)
+- **`xl`** - Extra large (text-4xl)
+- **`lg`** - Large (text-3xl)
+- **`base`** (default) - Base size (text-2xl)
+- **`sm`** - Small (text-xl)
+- **`xs`** - Extra small (text-lg)
+
+### Examples
+
+```tsx
+<Heading size="2xl" as="h1">Heading XXLarge</Heading>
+<Heading size="xl">Heading XLarge</Heading>
+<Heading size="lg">Heading Large</Heading>
+<Heading size="base">Heading Medium</Heading>
+<Heading size="sm">Heading Small</Heading>
+<Heading size="xs">Heading XSmall</Heading>
+```
+
+## Custom Styling
+
+The `className` prop can be used to add custom styles:
+
+```tsx
+<Heading as="h1" className="text-white mb-4">
+  Custom Styled Heading
+</Heading>
+```
+
+## Accessibility
+
+- Always use heading levels in a logical order (h1 → h2 → h3, etc.)
+- Don't skip heading levels for visual styling - use the `size` prop instead
+- Ensure headings accurately describe the content that follows
+
+### Example: Proper heading hierarchy
+
+```tsx
+<Heading as="h1" size="2xl">Page Title</Heading>
+<Heading as="h2" size="xl">Main Section</Heading>
+<Heading as="h3" size="lg">Subsection</Heading>
+<Heading as="h2" size="xl">Another Main Section</Heading>
+```
+
+## API Reference
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `as` | `'h1' \| 'h2' \| 'h3' \| 'h4' \| 'h5' \| 'h6'` | `'h2'` | The HTML heading element to render |
+| `size` | `'2xl' \| 'xl' \| 'lg' \| 'base' \| 'sm' \| 'xs'` | `'base'` | The text size of the heading |
+| `className` | `string` | `undefined` | Additional CSS classes to apply |
+
+The component also accepts all standard HTML heading attributes.

--- a/src/components/ui/heading/README.md
+++ b/src/components/ui/heading/README.md
@@ -90,7 +90,7 @@ The `className` prop can be used to add custom styles:
 
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
-| `as` | `'h1' \| 'h2' \| 'h3' \| 'h4' \| 'h5' \| 'h6'` | `'h2'` | The HTML heading element to render |
+| `as` | `'h1' \| 'h2' \| 'h3' \| 'h4' \| 'h5' \| 'h6'` | `'h1'` | The HTML heading element to render |
 | `size` | `'2xl' \| 'xl' \| 'lg' \| 'base' \| 'sm' \| 'xs'` | `'base'` | The text size of the heading |
 | `className` | `string` | `undefined` | Additional CSS classes to apply |
 

--- a/src/components/ui/heading/heading.variants.ts
+++ b/src/components/ui/heading/heading.variants.ts
@@ -1,0 +1,19 @@
+import { cva, type VariantProps } from 'class-variance-authority'
+
+export type HeadingProps = VariantProps<typeof headingVariants>
+
+export const headingVariants = cva('font-semibold text-foreground', {
+	defaultVariants: {
+		size: 'base',
+	},
+	variants: {
+		size: {
+			'2xl': 'text-5xl',
+			base: 'text-2xl',
+			lg: 'text-3xl',
+			sm: 'text-xl',
+			xl: 'text-4xl',
+			xs: 'text-lg',
+		},
+	},
+})

--- a/src/components/ui/heading/index.tsx
+++ b/src/components/ui/heading/index.tsx
@@ -1,0 +1,29 @@
+import { cn } from '@/libs/utils'
+import type { VariantProps } from 'class-variance-authority'
+import type { ComponentPropsWithoutRef, ElementType } from 'react'
+import { forwardRef } from 'react'
+import { headingVariants } from './heading.variants'
+
+type HeadingLevel = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
+
+export type HeadingProps = ComponentPropsWithoutRef<'h1'> &
+	VariantProps<typeof headingVariants> & {
+		as?: HeadingLevel
+	}
+
+export const Heading = forwardRef<HTMLHeadingElement, HeadingProps>(
+	({ className, size, as, ...props }, ref) => {
+		const Tag: ElementType = as || 'h1'
+
+		return (
+			<Tag
+				className={cn(headingVariants({ size }), className)}
+				data-slot="heading"
+				ref={ref}
+				{...props}
+			/>
+		)
+	},
+)
+
+Heading.displayName = 'Heading'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export * from '@/components/ui/avatar'
 export * from '@/components/ui/button'
+export * from '@/components/ui/heading'
 export * from '@/components/ui/icon-button'

--- a/src/stories/heading.stories.tsx
+++ b/src/stories/heading.stories.tsx
@@ -1,0 +1,143 @@
+import { Heading } from '@/components/ui/heading'
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { expect, within } from 'storybook/test'
+
+const meta = {
+	args: {
+		children: 'Heading Text',
+		size: 'base',
+	},
+	argTypes: {
+		as: {
+			control: 'select',
+			description: 'The HTML heading element to render',
+			options: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'],
+		},
+		size: {
+			control: 'select',
+			description: 'The text size of the heading',
+			options: ['2xl', 'xl', 'lg', 'base', 'sm', 'xs'],
+		},
+	},
+	component: Heading,
+	parameters: {
+		a11y: { test: 'error' },
+	},
+	tags: ['autodocs'],
+	title: 'Components/Heading',
+} satisfies Meta<typeof Heading>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+	args: {
+		children: 'Default Heading',
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement)
+
+		const heading = canvas.getByRole('heading', { name: 'Default Heading' })
+
+		await expect(heading).toHaveAttribute('data-slot', 'heading')
+		await expect(heading).toHaveTextContent('Default Heading')
+		await expect(heading.tagName).toBe('H1')
+	},
+}
+
+export const WithAs: Story = {
+	args: {
+		as: 'h2',
+		children: 'H2 Heading',
+		size: '2xl',
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement)
+		const heading = canvas.getByRole('heading', { level: 2, name: 'H2 Heading' })
+
+		await expect(heading.tagName).toBe('H2')
+	},
+}
+
+export const Size2XL: Story = {
+	args: {
+		children: 'Heading XXLarge',
+		size: '2xl',
+	},
+}
+
+export const SizeXL: Story = {
+	args: {
+		children: 'Heading XLarge',
+		size: 'xl',
+	},
+}
+
+export const SizeLarge: Story = {
+	args: {
+		children: 'Heading Large',
+		size: 'lg',
+	},
+}
+
+export const SizeBase: Story = {
+	args: {
+		children: 'Heading Medium',
+		size: 'base',
+	},
+}
+
+export const SizeSmall: Story = {
+	args: {
+		children: 'Heading Small',
+		size: 'sm',
+	},
+}
+
+export const SizeXSmall: Story = {
+	args: {
+		children: 'Heading XSmall',
+		size: 'xs',
+	},
+}
+
+export const WithCustomClass: Story = {
+	args: {
+		as: 'h1',
+		children: 'Custom Styled Heading',
+		className: 'text-blue-600 underline',
+		size: 'xl',
+	},
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement)
+		const heading = canvas.getByRole('heading', { name: 'Custom Styled Heading' })
+
+		await expect(heading).toHaveClass('text-blue-600')
+		await expect(heading).toHaveClass('underline')
+	},
+}
+
+export const AllSizes: Story = {
+	render: () => (
+		<div className="space-y-4">
+			<Heading as="h1" size="2xl">
+				Heading XXLarge
+			</Heading>
+			<Heading as="h2" size="xl">
+				Heading XLarge
+			</Heading>
+			<Heading as="h3" size="lg">
+				Heading Large
+			</Heading>
+			<Heading as="h4" size="base">
+				Heading Medium
+			</Heading>
+			<Heading as="h5" size="sm">
+				Heading Small
+			</Heading>
+			<Heading as="h6" size="xs">
+				Heading XSmall
+			</Heading>
+		</div>
+	),
+}


### PR DESCRIPTION
Introduce a flexible Heading component that supports multiple size variants and polymorphic rendering for different heading levels. Include comprehensive usage examples and accessibility guidelines. Add stories for various heading configurations in Storybook.