### PR TITLE
chore: adjust button variants and stories

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,104 +1,104 @@
 {
-  "name": "@tc96/ui-react",
-  "private": false,
-  "version": "0.7.4",
-  "files": [
-    "dist",
-    "tailwind-preset.js"
-  ],
-  "publishConfig": {
-    "access": "public"
-  },
-  "sideEffects": false,
-  "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
-  "types": "./dist/index.d.ts",
-  "exports": {
-    ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
-      "default": "./dist/index.mjs"
-    },
-    "./styles.css": "./dist/styles/index.css",
-    "./tailwind-preset": {
-      "types": "./dist/config/tailwind-preset.d.ts",
-      "import": "./dist/config/tailwind-preset.mjs",
-      "require": "./dist/config/tailwind-preset.js",
-      "default": "./dist/config/tailwind-preset.mjs"
-    }
-  },
-  "scripts": {
-    "dev": "storybook dev -p 6006",
-    "build": "tsup",
-    "build:storybook": "storybook build",
-    "serve": "vite preview",
-    "lint:check": "biome check .",
-    "lint:fix": "biome check --write .",
-    "lint:format": "biome format --write .",
-    "lint:staged": "biome check . --staged --fix",
-    "lint:ci": "biome check --error-on-warnings .",
-    "prepare": "husky",
-    "test": "vitest",
-    "test:ci": "vitest run",
-    "test-storybook": "vitest --project=storybook",
-    "check:type": "tsc --noEmit",
-    "check:updates": "npm-check-updates -i --color"
-  },
-  "lint-staged": {
-    "src/**/*.{ts,tsx,js,jsx}": [
-      "biome check --write"
-    ],
-    "src/**/*.{json}": [
-      "biome format --write"
-    ]
-  },
-  "peerDependencies": {
-    "react": ">=19",
-    "react-dom": ">=19"
-  },
-  "dependencies": {
-    "@changesets/cli": "^2.29.7",
-    "@radix-ui/react-avatar": "^1.1.11",
-    "@radix-ui/react-navigation-menu": "^1.2.14",
-    "@radix-ui/react-slot": "^1.2.4",
-    "@tailwindcss/vite": "^4.1.17",
-    "class-variance-authority": "^0.7.1",
-    "clsx": "^2.1.1",
-    "lucide-react": "^0.552.0",
-    "tailwind-merge": "^3.4.0",
-    "tailwindcss": "^4.1.17",
-    "tailwindcss-animate": "^1.0.7"
-  },
-  "devDependencies": {
-    "@biomejs/biome": "2.3.4",
-    "@chromatic-com/storybook": "^4.1.3",
-    "@commitlint/cli": "20.1.0",
-    "@commitlint/config-conventional": "20.0.0",
-    "@storybook/addon-a11y": "^10.1.4",
-    "@storybook/addon-docs": "^10.1.4",
-    "@storybook/addon-links": "^10.1.4",
-    "@storybook/addon-onboarding": "^10.1.4",
-    "@storybook/addon-themes": "^10.1.4",
-    "@storybook/addon-vitest": "^10.1.4",
-    "@storybook/react-vite": "^10.1.4",
-    "@tc96/biome-config": "^2.2.0",
-    "@types/node": "^24.10.1",
-    "@types/react": "^19.2.4",
-    "@types/react-dom": "^19.2.3",
-    "@vitejs/plugin-react": "^5.1.1",
-    "@vitest/browser-playwright": "^4.0.8",
-    "@vitest/coverage-v8": "^4.0.8",
-    "autoprefixer": "^10.4.22",
-    "globals": "^16.5.0",
-    "husky": "^9.1.7",
-    "lint-staged": "^16.1.5",
-    "npm-check-updates": "^19.1.2",
-    "playwright": "^1.56.1",
-    "storybook": "^10.1.4",
-    "tsup": "^8.5.1",
-    "typescript": "~5.9.3",
-    "vite": "^7.2.2",
-    "vitest": "^4.0.8"
-  }
+	"name": "@tc96/ui-react",
+	"private": false,
+	"version": "0.7.5",
+	"files": [
+		"dist",
+		"tailwind-preset.js"
+	],
+	"publishConfig": {
+		"access": "public"
+	},
+	"sideEffects": false,
+	"main": "./dist/index.js",
+	"module": "./dist/index.mjs",
+	"types": "./dist/index.d.ts",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.mjs",
+			"require": "./dist/index.js",
+			"default": "./dist/index.mjs"
+		},
+		"./styles.css": "./dist/styles/index.css",
+		"./tailwind-preset": {
+			"types": "./dist/config/tailwind-preset.d.ts",
+			"import": "./dist/config/tailwind-preset.mjs",
+			"require": "./dist/config/tailwind-preset.js",
+			"default": "./dist/config/tailwind-preset.mjs"
+		}
+	},
+	"scripts": {
+		"dev": "storybook dev -p 6006",
+		"build": "tsup",
+		"build:storybook": "storybook build",
+		"serve": "vite preview",
+		"lint:check": "biome check .",
+		"lint:fix": "biome check --write .",
+		"lint:format": "biome format --write .",
+		"lint:staged": "biome check . --staged --fix",
+		"lint:ci": "biome check --error-on-warnings .",
+		"prepare": "husky",
+		"test": "vitest",
+		"test:ci": "vitest run",
+		"test-storybook": "vitest --project=storybook",
+		"check:type": "tsc --noEmit",
+		"check:updates": "npm-check-updates -i --color"
+	},
+	"lint-staged": {
+		"src/**/*.{ts,tsx,js,jsx}": [
+			"biome check --write"
+		],
+		"src/**/*.{json}": [
+			"biome format --write"
+		]
+	},
+	"peerDependencies": {
+		"react": ">=19",
+		"react-dom": ">=19"
+	},
+	"dependencies": {
+		"@changesets/cli": "^2.29.7",
+		"@radix-ui/react-avatar": "^1.1.11",
+		"@radix-ui/react-navigation-menu": "^1.2.14",
+		"@radix-ui/react-slot": "^1.2.4",
+		"@tailwindcss/vite": "^4.1.17",
+		"class-variance-authority": "^0.7.1",
+		"clsx": "^2.1.1",
+		"lucide-react": "^0.552.0",
+		"tailwind-merge": "^3.4.0",
+		"tailwindcss": "^4.1.17",
+		"tailwindcss-animate": "^1.0.7"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "2.3.4",
+		"@chromatic-com/storybook": "^4.1.3",
+		"@commitlint/cli": "20.1.0",
+		"@commitlint/config-conventional": "20.0.0",
+		"@storybook/addon-a11y": "^10.1.4",
+		"@storybook/addon-docs": "^10.1.4",
+		"@storybook/addon-links": "^10.1.4",
+		"@storybook/addon-onboarding": "^10.1.4",
+		"@storybook/addon-themes": "^10.1.4",
+		"@storybook/addon-vitest": "^10.1.4",
+		"@storybook/react-vite": "^10.1.4",
+		"@tc96/biome-config": "^2.2.0",
+		"@types/node": "^24.10.1",
+		"@types/react": "^19.2.4",
+		"@types/react-dom": "^19.2.3",
+		"@vitejs/plugin-react": "^5.1.1",
+		"@vitest/browser-playwright": "^4.0.8",
+		"@vitest/coverage-v8": "^4.0.8",
+		"autoprefixer": "^10.4.22",
+		"globals": "^16.5.0",
+		"husky": "^9.1.7",
+		"lint-staged": "^16.1.5",
+		"npm-check-updates": "^19.1.2",
+		"playwright": "^1.56.1",
+		"storybook": "^10.1.4",
+		"tsup": "^8.5.1",
+		"typescript": "~5.9.3",
+		"vite": "^7.2.2",
+		"vitest": "^4.0.8"
+	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       '@storybook/addon-a11y':
         specifier: ^10.1.4
         version: 10.1.4(storybook@10.1.4(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
+      '@storybook/addon-actions':
+        specifier: ^9.0.8
+        version: 9.0.8
       '@storybook/addon-docs':
         specifier: ^10.1.4
         version: 10.1.4(@types/react@19.2.4)(esbuild@0.27.0)(rollup@4.53.2)(storybook@10.1.4(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@7.2.2(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.1))
@@ -1161,6 +1164,9 @@ packages:
     resolution: {integrity: sha512-go7SshAyu+pnK7Prq3UnCBCB7DxAQkPMnebsv3fnboeTZHnDXQqfmHdZ15o+pH0JsCedC05RYsdbjd2rMHMvFQ==}
     peerDependencies:
       storybook: ^10.1.4
+
+  '@storybook/addon-actions@9.0.8':
+    resolution: {integrity: sha512-LFePu7PPnWN0Il/uoUpmA5T0J0C7d6haJIbg0pXrjxW2MQVSYXE4S4LSUz8fOImltBDV3xAl6tLPYHFj6VcrOA==}
 
   '@storybook/addon-docs@10.1.4':
     resolution: {integrity: sha512-TWLDJNLS/S3AUyTf9x0Hb8k7d+VWMJCH9dWAS0QenvJG8ga9VaehO6r+e+3YyIDbO1ev3UST3GCjh9SY8tzwRA==}
@@ -3973,6 +3979,8 @@ snapshots:
       '@storybook/global': 5.0.0
       axe-core: 4.11.0
       storybook: 10.1.4(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+
+  '@storybook/addon-actions@9.0.8': {}
 
   '@storybook/addon-docs@10.1.4(@types/react@19.2.4)(esbuild@0.27.0)(rollup@4.53.2)(storybook@10.1.4(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@7.2.2(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.1))':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,9 +63,6 @@ importers:
       '@storybook/addon-a11y':
         specifier: ^10.1.4
         version: 10.1.4(storybook@10.1.4(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))
-      '@storybook/addon-actions':
-        specifier: ^9.0.8
-        version: 9.0.8
       '@storybook/addon-docs':
         specifier: ^10.1.4
         version: 10.1.4(@types/react@19.2.4)(esbuild@0.27.0)(rollup@4.53.2)(storybook@10.1.4(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@7.2.2(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.1))
@@ -1164,9 +1161,6 @@ packages:
     resolution: {integrity: sha512-go7SshAyu+pnK7Prq3UnCBCB7DxAQkPMnebsv3fnboeTZHnDXQqfmHdZ15o+pH0JsCedC05RYsdbjd2rMHMvFQ==}
     peerDependencies:
       storybook: ^10.1.4
-
-  '@storybook/addon-actions@9.0.8':
-    resolution: {integrity: sha512-LFePu7PPnWN0Il/uoUpmA5T0J0C7d6haJIbg0pXrjxW2MQVSYXE4S4LSUz8fOImltBDV3xAl6tLPYHFj6VcrOA==}
 
   '@storybook/addon-docs@10.1.4':
     resolution: {integrity: sha512-TWLDJNLS/S3AUyTf9x0Hb8k7d+VWMJCH9dWAS0QenvJG8ga9VaehO6r+e+3YyIDbO1ev3UST3GCjh9SY8tzwRA==}
@@ -3979,8 +3973,6 @@ snapshots:
       '@storybook/global': 5.0.0
       axe-core: 4.11.0
       storybook: 10.1.4(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-
-  '@storybook/addon-actions@9.0.8': {}
 
   '@storybook/addon-docs@10.1.4(@types/react@19.2.4)(esbuild@0.27.0)(rollup@4.53.2)(storybook@10.1.4(@testing-library/dom@10.4.0)(prettier@2.8.8)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(vite@7.2.2(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.1))':
     dependencies:

--- a/src/components/ui/button/button.stories.tsx
+++ b/src/components/ui/button/button.stories.tsx
@@ -4,7 +4,21 @@ import { expect, fn, within } from 'storybook/test'
 
 const meta = {
 	args: {
+		children: 'Button',
 		onClick: fn(),
+		size: 'base',
+	},
+	argTypes: {
+		size: {
+			control: 'inline-radio',
+			defaultValue: 'base',
+			options: ['sm', 'base', 'lg'],
+		},
+		variant: {
+			control: 'select',
+			defaultValue: 'primary',
+			options: ['primary', 'secondary', 'accent', 'ghost', 'link'],
+		},
 	},
 	component: Button,
 	parameters: {
@@ -17,9 +31,9 @@ const meta = {
 export default meta
 type Story = StoryObj<typeof meta>
 
-export const Primary: Story = {
+export const Default: Story = {
 	args: {
-		children: 'Primary',
+		size: 'base',
 		variant: 'primary',
 	},
 	play: async ({ canvasElement, userEvent, args }) => {
@@ -28,8 +42,9 @@ export const Primary: Story = {
 
 		await expect(button).toHaveRole('button')
 		await expect(button).toHaveAttribute('data-slot', 'button')
-		await expect(button).toHaveTextContent('Primary')
+		await expect(button).toHaveTextContent('Button')
 		await expect(button).toHaveClass(/bg-primary/)
+		await expect(button).toHaveClass(/rounded-sm/)
 
 		await expect(button).not.toBeDisabled()
 
@@ -40,7 +55,7 @@ export const Primary: Story = {
 
 export const Secondary: Story = {
 	args: {
-		children: 'Secondary',
+		size: 'base',
 		variant: 'secondary',
 	},
 	play: async ({ canvasElement }) => {
@@ -54,7 +69,7 @@ export const Secondary: Story = {
 
 export const Accent: Story = {
 	args: {
-		children: 'Accent',
+		size: 'base',
 		variant: 'accent',
 	},
 	play: async ({ canvasElement }) => {
@@ -68,7 +83,7 @@ export const Accent: Story = {
 
 export const Destructive: Story = {
 	args: {
-		children: 'Destructive',
+		size: 'base',
 		variant: 'destructive',
 	},
 	play: async ({ canvasElement }) => {
@@ -82,7 +97,7 @@ export const Destructive: Story = {
 
 export const Outline: Story = {
 	args: {
-		children: 'Outline',
+		size: 'base',
 		variant: 'outline',
 	},
 	play: async ({ canvasElement }) => {
@@ -97,7 +112,7 @@ export const Outline: Story = {
 
 export const Ghost: Story = {
 	args: {
-		children: 'Ghost',
+		size: 'base',
 		variant: 'ghost',
 	},
 	play: async ({ canvasElement }) => {
@@ -112,7 +127,7 @@ export const Ghost: Story = {
 
 export const Link: Story = {
 	args: {
-		children: 'Link',
+		size: 'base',
 		variant: 'link',
 	},
 	play: async ({ canvasElement }) => {
@@ -126,7 +141,6 @@ export const Link: Story = {
 
 export const Small: Story = {
 	args: {
-		children: 'Small Button',
 		size: 'sm',
 		variant: 'primary',
 	},
@@ -135,13 +149,11 @@ export const Small: Story = {
 		const button = canvas.getByRole('button')
 
 		await expect(button).toHaveClass(/h-9/)
-		await expect(button).toHaveClass(/rounded-sm/)
 	},
 }
 
 export const Base: Story = {
 	args: {
-		children: 'Base Button',
 		size: 'base',
 		variant: 'primary',
 	},
@@ -150,13 +162,11 @@ export const Base: Story = {
 		const button = canvas.getByRole('button')
 
 		await expect(button).toHaveClass(/h-10/)
-		await expect(button).toHaveClass(/rounded-md/)
 	},
 }
 
 export const Large: Story = {
 	args: {
-		children: 'Large Button',
 		size: 'lg',
 		variant: 'primary',
 	},
@@ -165,14 +175,12 @@ export const Large: Story = {
 		const button = canvas.getByRole('button')
 
 		await expect(button).toHaveClass(/h-12/)
-		await expect(button).toHaveClass(/rounded-md/)
 	},
 }
 
 export const Disabled: Story = {
 	args: {
 		'aria-disabled': 'true',
-		children: 'Disabled',
 		disabled: true,
 		variant: 'primary',
 	},

--- a/src/components/ui/button/button.variants.ts
+++ b/src/components/ui/button/button.variants.ts
@@ -1,7 +1,7 @@
 import { cva } from 'class-variance-authority'
 
 export const buttonVariants = cva(
-	'inline-flex items-center justify-center gap-2 transition-colors ease-linear duration-75 whitespace-nowrap rounded-sm text-sm font-semibold disabled:pointer-events-none disabled:bg-primary/30 disabled:border-primary/30 disabled:text-primary/50 [&_svg]:pointer-events-none [&_svg:not([class*="size-"])]:size-4 [&_svg]:shrink-0 ring-ring/10 dark:ring-ring/20 dark:outline-ring/40 outline-ring/50 focus-visible:ring-4 focus-visible:outline-1 aria-invalid:focus-visible:ring-0',
+	'inline-flex items-center justify-center gap-2 transition-colors ease-linear duration-75 whitespace-nowrap rounded-sm font-semibold disabled:pointer-events-none disabled:bg-primary/30 disabled:border-primary/30 disabled:text-primary/50 [&_svg]:pointer-events-none [&_svg:not([class*="size-"])]:size-4 [&_svg]:shrink-0 ring-ring/10 dark:ring-ring/20 dark:outline-ring/40 outline-ring/50 focus-visible:ring-4 focus-visible:outline-1 aria-invalid:focus-visible:ring-0',
 	{
 		compoundVariants: [
 			{
@@ -31,9 +31,9 @@ export const buttonVariants = cva(
 				true: '',
 			},
 			size: {
-				base: 'h-10 rounded-md px-4 py-2 has-[>svg]:px-3',
-				lg: 'h-12 rounded-md px-6 has-[>svg]:px-4',
-				sm: 'h-9 rounded-sm px-3 has-[>svg]:px-2.5',
+				base: 'h-10 text-sm px-4 py-2 has-[>svg]:px-3',
+				lg: 'h-12 text-base px-6 has-[>svg]:px-4',
+				sm: 'h-9 text-sm px-3 has-[>svg]:px-2.5',
 			},
 			variant: {
 				accent: 'bg-accent text-accent-foreground hover:bg-accent/80',

--- a/src/components/ui/button/icon.stories.tsx
+++ b/src/components/ui/button/icon.stories.tsx
@@ -32,6 +32,7 @@ export const Default: Story = {
 		await expect(button).toHaveClass(/size-10/)
 		await expect(button).toHaveClass(/p-0/)
 		await expect(button).toHaveClass(/gap-0/)
+		await expect(button).toHaveClass(/rounded-sm/)
 	},
 }
 


### PR DESCRIPTION
Move text sizing into size variants and unify rounded styles. Add size and variant controls to button stories and update tests. Bump package version to 0.7.5 and add @storybook/addon-actions to pnpm lockfile

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Refined button typography sizing for consistent appearance across different button sizes
  * Enhanced button component visual styling with improved rounded corner treatment

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->